### PR TITLE
Add template workflow to synchronize with shared repository labels

### DIFF
--- a/workflow-templates/assets/sync-labels/gh-label-configuration-schema.json
+++ b/workflow-templates/assets/sync-labels/gh-label-configuration-schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/oe5lxr/.github/main/workflow-templates/assets/sync-labels/gh-label-configuration-schema.json",
+  "title": "Repository label configuration file JSON schema",
+  "description": "Required structure of the configuration file used to define GitHub issue/PR labels, as well as the standardized format for labels. See: https://github.com/oe5lxr/.github/blob/main/workflow-templates/sync-labels.md",
+  "type": "array",
+  "uniqueItems": true,
+  "items": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "maxLength": 50,
+        "anyOf": [
+          {
+            "$comment": "Standardized label format",
+            "pattern": "^.+: .+$"
+          },
+          {
+            "$comment": "Allowed exceptions to the standardized format",
+            "enum": ["help wanted"]
+          }
+        ]
+      },
+      "color": {
+        "enum": [
+          "940404",
+          "ff0000",
+          "ffa200",
+          "ffff00",
+          "00ff00",
+          "92a600",
+          "008000",
+          "00ba9e",
+          "00ffff",
+          "0000ff",
+          "000080",
+          "800080",
+          "d876e3",
+          "ff00ff",
+          "c0c0c0"
+        ]
+      },
+      "description": {
+        "type": "string",
+        "maxLength": 100
+      },
+      "aliases": {
+        "type": "array"
+      },
+      "notes": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "additionalProperties": false,
+    "required": ["name", "color", "description"]
+  }
+}

--- a/workflow-templates/assets/sync-labels/universal.yml
+++ b/workflow-templates/assets/sync-labels/universal.yml
@@ -1,0 +1,84 @@
+- name: "conclusion: declined"
+  color: "940404"
+  description: Will not be worked on.
+  aliases:
+    - wontfix
+- name: "conclusion: duplicate"
+  color: "ff0000"
+  description: Has already been submitted.
+  aliases:
+    - duplicate
+- name: "conclusion: invalid"
+  color: "ff0000"
+  description: Off topic or not a bug.
+  aliases:
+    - invalid
+- name: "help wanted"
+  color: "ffa200"
+  description: Assistance from the community is especially welcome.
+- name: "priority: high"
+  color: "ffa200"
+  description: ""
+- name: "priority: low"
+  color: "c0c0c0"
+  description: ""
+- name: "status: changes requested"
+  color: "ffa200"
+  description: Changes to the PR are required before merging.
+- name: "status: in progress"
+  color: "0000ff"
+  description: Work is in progress on this.
+- name: "status: on hold"
+  color: "940404"
+  description: Do not proceed at this time.
+- name: "status: waiting for information"
+  color: "ffff00"
+  description: More information must be provided before work can proceed.
+- name: "status: blocked"
+  color: "940404"
+  description: Progress on this is prevented by an external cause.
+- name: "status: moved"
+  color: "000080"
+  description: This item was moved to another repository.
+- name: "topic: ci"
+  color: "00ffff"
+  description: Continuous integration for this repository.
+- name: "topic: firmware"
+  color: "00ffff"
+  description: Code that runs on an embedded system.
+- name: "topic: software"
+  color: "00ffff"
+  description: Code that runs on a PC.
+- name: "topic: mechanics"
+  color: "00ffff"
+  description: Mechanical components of the project.
+- name: "topic: electronics"
+  color: "00ffff"
+  description: Electronics components of the project.
+- name: "topic: documentation"
+  color: "00ffff"
+  description: Documentation for the project.
+  aliases:
+    - documentation
+- name: "topic: fpga"
+  color: "00ffff"
+  description: "FPGAs: HDL code, simulation, verification, and synthesis."
+- name: "type: bug"
+  color: "ff0000"
+  description: ""
+- name: "type: enhancement"
+  color: "008000"
+  description: PR to improve the project.
+  aliases:
+    - enhancement
+- name: "type: feature request"
+  color: "008000"
+  description: Issue requesting a new feature to be added.
+- name: "type: support"
+  color: "ffff00"
+  description: Request for help using the project.
+  aliases:
+    - question
+- name: "type: priority support"
+  color: "ffff00"
+  description: Guaranteed response within a workday.

--- a/workflow-templates/label.svg
+++ b/workflow-templates/label.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<svg
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:cc="http://creativecommons.org/ns#"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:svg="http://www.w3.org/2000/svg"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+  version="1.1"
+  x="0px"
+  y="0px"
+  viewBox="0 0 157.70413 160.76103"
+  enable-background="new 0 0 100 100"
+  xml:space="preserve"
+  id="svg10"
+  sodipodi:docname="manage-labels.svg"
+  width="157.70413"
+  height="160.76103"
+  inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+><metadata id="metadata16"><rdf:RDF><cc:Work rdf:about=""><dc:format
+        >image/svg+xml</dc:format><dc:type
+          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+        /><dc:title /><cc:license
+          rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/"
+        /><dc:creator><cc:Agent><dc:title
+            >John Cummings</dc:title></cc:Agent></dc:creator><dc:rights
+        ><cc:Agent><dc:title
+            >Creative Commons Attribution-ShareAlike 4.0 International
+</dc:title></cc:Agent></dc:rights><dc:source
+        >https://commons.wikimedia.org/wiki/File:Noun_Project_label_icon_1116097_cc_mirror.svg</dc:source></cc:Work><cc:License
+        rdf:about="http://creativecommons.org/licenses/by-sa/4.0/"
+      ><cc:permits
+          rdf:resource="http://creativecommons.org/ns#Reproduction"
+        /><cc:permits
+          rdf:resource="http://creativecommons.org/ns#Distribution"
+        /><cc:requires
+          rdf:resource="http://creativecommons.org/ns#Notice"
+        /><cc:requires
+          rdf:resource="http://creativecommons.org/ns#Attribution"
+        /><cc:permits
+          rdf:resource="http://creativecommons.org/ns#DerivativeWorks"
+        /><cc:requires
+          rdf:resource="http://creativecommons.org/ns#ShareAlike"
+        /></cc:License></rdf:RDF></metadata><defs
+    id="defs14"
+  /><sodipodi:namedview
+    pagecolor="#ffffff"
+    bordercolor="#666666"
+    borderopacity="1"
+    objecttolerance="10"
+    gridtolerance="10"
+    guidetolerance="10"
+    inkscape:pageopacity="0"
+    inkscape:pageshadow="2"
+    inkscape:window-width="1366"
+    inkscape:window-height="705"
+    id="namedview12"
+    showgrid="false"
+    fit-margin-top="10"
+    fit-margin-left="10"
+    fit-margin-right="10"
+    fit-margin-bottom="10"
+    inkscape:zoom="1.888"
+    inkscape:cx="-20.707247"
+    inkscape:cy="-51.568181"
+    inkscape:window-x="-8"
+    inkscape:window-y="-8"
+    inkscape:window-maximized="1"
+    inkscape:current-layer="svg10"
+  /><path
+    d="m 69.146834,150.76103 c 4.426971,0 9.037479,-1.75719 13.704067,-5.2257 0.108763,-0.0799 0.209028,-0.16824 0.302496,-0.26171 L 139.29011,87.947319 c 7.21231,-5.73552 9.80731,-14.168008 7.71024,-25.066344 L 144.45803,12.422 c -0.0697,-1.373126 -1.159,-2.4437566 -2.58821,-2.421664 L 92.948814,10.846644 C 82.006293,9.4225353 73.691064,12.515468 68.297127,19.953799 L 14.602465,79.756147 c -0.0833,0.09177 -0.15635,0.186936 -0.22602,0.288901 -6.4322798,9.647568 -5.7644098,18.785313 1.93903,26.422482 l 40.72304,39.52834 c 0.0527,0.0527 0.10706,0.10027 0.16314,0.14615 3.742111,3.06405 7.762923,4.61901 11.945179,4.61901 z m 10.507471,-9.20232 c -3.714917,2.72586 -7.246297,4.10408 -10.509171,4.10408 -2.989267,0 -5.811993,-1.11312 -8.636417,-3.40053 L 19.885935,102.82908 c -5.93605,-5.890166 -6.37959,-12.19329 -1.36802,-19.803262 l 53.66577,-59.76666 c 0.06288,-0.06798 0.118959,-0.141052 0.176739,-0.217525 4.318209,-6.032917 10.91703,-8.350917 20.104057,-7.117143 0.129156,0.01699 0.265109,0.01869 0.385767,0.02379 l 46.643792,-0.807219 2.42336,48.178363 c 0.007,0.122357 0.0238,0.246414 0.0459,0.365373 1.79968,9.144543 -0.14954,15.806242 -5.95474,20.35897 -0.0867,0.06628 -0.16994,0.142751 -0.24641,0.222623 z"
+    id="path2"
+    inkscape:connector-curvature="0"
+    style="stroke-width:1.69941318"
+  /><path
+    d="m 120.84128,50.701281 c 3.72682,0 6.9574,-1.4479 9.60169,-4.301215 2.56271,-2.487941 3.90695,-5.67604 3.90695,-9.379061 0,-4.042904 -1.34424,-7.400944 -4.00042,-9.984052 -2.58821,-2.661281 -5.8052,-4.036106 -9.50992,-4.036106 -3.70812,0 -7.03727,1.344236 -9.89058,3.99532 -2.69867,2.623894 -4.0463,5.983634 -4.0463,10.024838 0,3.703021 1.34763,6.89112 4.00211,9.472529 2.86012,2.792136 6.20626,4.207747 9.93647,4.207747 z m 0,-22.602195 c 2.30611,0 4.23834,0.829314 5.90546,2.542322 1.70282,1.658627 2.50664,3.728513 2.50664,6.379597 0,2.306104 -0.80382,4.211146 -2.45565,5.818791 -1.7555,1.891447 -3.67074,2.763246 -5.95475,2.763246 -2.38937,0 -4.47455,-0.902389 -6.3762,-2.759847 -1.66032,-1.611044 -2.46245,-3.514387 -2.46245,-5.82219 0,-2.651084 0.80383,-4.72097 2.45906,-6.330314 1.86425,-1.731702 3.96643,-2.591605 6.37789,-2.591605 z"
+    id="path4"
+    inkscape:connector-curvature="0"
+    style="stroke-width:1.69941318"
+  /></svg>

--- a/workflow-templates/sync-labels.md
+++ b/workflow-templates/sync-labels.md
@@ -1,0 +1,92 @@
+# "Sync Labels" workflow
+
+Workflow file: [sync-labels.yml](sync-labels.yml)
+
+Use [github-label-sync](https://github.com/Financial-Times/github-label-sync) to configure the repository's [issue/pull request labels](https://docs.github.com/en/github/managing-your-work-on-github/managing-labels) according to the universal, shared, and local label configuration files.
+
+Use of consistent labels across repositories makes repository maintenance and searching of issue and pull request trackers easier.
+
+Some label definitions in the configuration file contain a `notes` field. This provides additional information about the proper usage of the label when this might not be clear from the label name and description. The `notes` field is purely for documentation purposes and has no effect on the repository labels.
+
+## Non-universal labels
+
+Multiple labels data files can be merged to form the list of labels for the repository. The [universal labels](assets/sync-labels/universal.yml) must be used in all repositories, but some projects will benefit from the addition of other domain-specific labels.
+
+The configuration file structure is documented here: https://github.com/Financial-Times/github-label-sync#label-config-file
+
+Configuration files for labels that are applicable to multiple projects are hosted [here](assets/sync-labels).
+Add the file name to the `jobs.download.strategy.matrix.filename[]` in the workflow.
+
+The configuration file for labels that only apply to the specific project should be located at `.github/label-configuration-files/local.yml`
+
+### Maximum string lengths
+
+Label sync will fail with a `422: Validation Failed` error if a label configuration string exceeds the maximum length.
+
+- `name`: 50
+- `description`: 100
+  - Note: `description` is truncated at ~45 (depending on width) characters in the labeling menu, so make sure the meaning of the label is clear to the maintainer from the visible subset of the description.
+
+### Standardized label colors
+
+These colors have good contrast. When possible, follow the conventions established in the universal labels for the general meaning associated the colors.
+
+- `#940404`
+- `#ff0000`
+- `#ffa200`
+- `#ffff00`
+- `#00ff00`
+- `#92a600`
+- `#008000`
+- `#00ba9e`
+- `#00ffff`
+- `#0000ff`
+- `#000080`
+- `#800080`
+- `#d876e3`
+- `#ff00ff`
+- `#c0c0c0`
+
+#### Notes
+
+- Remove the `#` from the hex color code before adding it to the `color` field of the labels definition file.
+- Black and white should not be used due to lacking contrast with the GitHub page background colors (light and dark themes).
+
+## Readme badge
+
+Markdown badge:
+
+```markdown
+[![Sync Labels status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/sync-labels.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/sync-labels.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/sync-labels.yml/badge.svg["Sync Labels status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/sync-labels.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add CI workflow to synchronize with shared repository labels
+
+On every push that changes relevant files, and periodically, configure the repository's issue and pull request labels
+according to the universal, shared, and local label configuration files.
+```
+
+## PR message
+
+```markdown
+On every push that changes relevant files, and periodically, use [github-label-sync](https://github.com/Financial-Times/github-label-sync) to configure the repository's issue/PR labels according to the universal, shared, and local label configuration files.
+```
+
+## Related
+
+- ["Check Workflows" workflow](check-workflows.md)

--- a/workflow-templates/sync-labels.properties.json
+++ b/workflow-templates/sync-labels.properties.json
@@ -1,0 +1,5 @@
+{
+  "name": "Sync Labels",
+  "description": "Sync repository labels with a centralized source list.",
+  "iconName": "label"
+}

--- a/workflow-templates/sync-labels.yml
+++ b/workflow-templates/sync-labels.yml
@@ -1,0 +1,151 @@
+# Source: https://github.com/oe5lxr/.github/blob/main/workflow-templates/sync-labels.md
+name: Sync Labels
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/sync-labels.yml"
+      - ".github/label-configuration-files/*.yml"
+  pull_request:
+    paths:
+      - ".github/workflows/sync-labels.yml"
+      - ".github/label-configuration-files/*.yml"
+  schedule:
+    # Run daily at 8 AM UTC to sync with changes to shared label configurations.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+env:
+  CONFIGURATIONS_FOLDER: .github/label-configuration-files
+  CONFIGURATIONS_ARTIFACT: label-configuration-files
+
+jobs:
+  check:
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download JSON schema for labels configuration file
+        id: download-schema
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          file-url: https://raw.githubusercontent.com/oe5lxr/.github/main/workflow-templates/assets/sync-labels/gh-label-configuration-schema.json
+          location: ${{ runner.temp }}/label-configuration-schema
+
+      - name: Get week number for use in cache key
+        id: get-date
+        run: |
+          echo "::set-output name=week-number::$(date --utc '+%V')"
+
+      - name: Load dependencies cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-ajv-cli-${{ steps.get-date.outputs.week-number }}
+          restore-keys: |
+            ${{ runner.os }}-node-ajv-cli-
+
+      - name: Install JSON schema validator
+        run: sudo npm install --global ajv-cli
+
+      - name: Validate local labels configuration
+        run: |
+          # See: https://github.com/ajv-validator/ajv-cli#readme
+          ajv validate \
+            -s "${{ steps.download-schema.outputs.file-path }}" \
+            -d "${{ env.CONFIGURATIONS_FOLDER }}/*.{yml,yaml}"
+
+  download:
+    needs: check
+    if: always() && (needs.check.result == 'skipped' || needs.check.result == 'success')
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        filename:
+          # Filenames of the configurations to apply to the repository in addition to the local configuration.
+          # https://github.com/oe5lxr/.github/blob/main/workflow-templates/assets/sync-labels
+          - universal.yml
+
+    steps:
+      - name: Download
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          file-url: https://raw.githubusercontent.com/oe5lxr/.github/main/workflow-templates/assets/sync-labels/${{ matrix.filename }}
+
+      - name: Pass configuration files to next job via workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: "*.yml"
+          if-no-files-found: error
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+
+  sync:
+    needs: download
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >> "$GITHUB_ENV"
+
+      - name: Determine whether to dry run
+        id: dry-run
+        if: >-
+          github.event == 'pull_request' ||
+          github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+        run: |
+          # Use of this flag in the github-label-sync command will cause it to only check the validity of the
+          # configuration.
+          echo "::set-output name=flag::--dry-run"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download configuration files artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          path: ${{ env.CONFIGURATIONS_FOLDER }}
+
+      - name: Remove unneeded artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+
+      - name: Merge label configuration files
+        run: |
+          # Merge all configuration files
+          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.yml > "${{ env.MERGED_CONFIGURATION_PATH }}"
+
+      - name: Get week number for use in cache key
+        id: get-date
+        run: |
+          echo "::set-output name=week-number::$(date --utc '+%V')"
+
+      - name: Load dependencies cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-github-label-sync-${{ steps.get-date.outputs.week-number }}
+          restore-keys: |
+            ${{ runner.os }}-node-github-label-sync-
+
+      - name: Install github-label-sync
+        run: sudo npm install --global github-label-sync
+
+      - name: Sync labels
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # See: https://github.com/Financial-Times/github-label-sync
+          github-label-sync \
+            --labels "${{ env.MERGED_CONFIGURATION_PATH }}" \
+            ${{ steps.dry-run.outputs.flag }} \
+            ${{ github.repository }}


### PR DESCRIPTION
On every push that changes relevant files, and periodically, this workflow template will use [github-label-sync](https://github.com/Financial-Times/github-label-sync) to configure the repository's issue/PR labels according to the universal, shared, and local label configuration files.